### PR TITLE
Add ability to have different style for selected value

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -9,10 +9,26 @@ const propTypes = {
   selectedValueIndex: PropTypes.string,
   onValueChange: PropTypes.func,
   data: PropTypes.array,
-  style: PropTypes.object,
-  textStyle: PropTypes.object,
-  pickerItemStyle: PropTypes.object,
-  collapseViewStyle: PropTypes.object,
+  style: PropTypes.oneOfType([
+    PropTypes.object,
+    PropTypes.array
+  ]),
+  textStyle: PropTypes.oneOfType([
+    PropTypes.object,
+    PropTypes.array
+  ]),
+  selectedTextStyle: PropTypes.oneOfType([
+    PropTypes.object,
+    PropTypes.array
+  ]),
+  pickerItemStyle: PropTypes.oneOfType([
+    PropTypes.object,
+    PropTypes.array
+  ]),
+  collapseViewStyle: PropTypes.oneOfType([
+    PropTypes.object,
+    PropTypes.array
+  ]),
 }
 
 const defaultProps = {
@@ -90,7 +106,7 @@ class IOSPicker extends Component {
   }
 
   renderModalPicker() {
-    const { style, textStyle } = this.props;
+    const { style, selectedTextStyle, textStyle } = this.props;
     return (
     <View>
       <TouchableOpacity 
@@ -98,7 +114,7 @@ class IOSPicker extends Component {
         onPress={this.pressItem}
         style={[defaultStyles.container,style]}
       >
-        <Text style={textStyle}>
+        <Text style={this.state.modalVisible ? selectedTextStyle : textStyle}>
           {this.state.selectedValue}
         </Text>
       </TouchableOpacity>


### PR DESCRIPTION
- This change originated from a requirement of our mobile app to show selected value in a different color when the picker is active
- A new prop `selectedTextStyle` was added to show different style when modal is visible
- All style related props were updated to allow array as prop type so that custom components that use react-native-ios-picker can have more flexibility on how styles are applied